### PR TITLE
Add support for "not" operator on environment variables

### DIFF
--- a/yaml_env_tag.py
+++ b/yaml_env_tag.py
@@ -27,10 +27,15 @@ def construct_env_tag(loader: yaml.Loader, node: yaml.Node) -> Any:
         )
 
     for var in vars:
+        if var.startswith("~"):
+            var = var[1:]
+            not_var = true
         if var in os.environ:
             value = os.environ[var]
             # Resolve value to Python type using YAML's implicit resolvers
             tag = loader.resolve(yaml.nodes.ScalarNode, value, (True, False))
+            if not_var:
+                tag = not tag
             return loader.construct_object(yaml.nodes.ScalarNode(tag, value))
 
     return default


### PR DESCRIPTION
In my scenario, I have an environment variable that is used by two different keys in my yaml config in opposite directions. This change would allow adding the `~` prefix to an environment variable name to "not" it.

### Example
```yaml
key1: !ENV MY_VAR
key2: !ENV ~MY_VAR
```

I do not think this pull request is complete or even the right idea entirely, I just wanted to propose a potential solution.